### PR TITLE
fix: use pinned blurb version

### DIFF
--- a/prepare_binary
+++ b/prepare_binary
@@ -3,4 +3,4 @@ DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS nobench nolto nopgo"
 apt install python3-pip libgdbm-compat-dev -y
 # Python uses blurb to create NEWS entries and there is not debian package.
 # Do a unclean installation via pip to allow to generate the NEWS.
-pip install --break-system-packages blurb
+pip install --break-system-packages blurb==1.3.0


### PR DESCRIPTION
Pin to older blurb version for now and let's wait for either python to backport https://github.com/python/cpython/pull/128875 to 3.12 or for debian to adopt the patch. If not we can pull in that patch ourselves later, but pinning a specific version of blurb should be done regardless even once we update to 2.0 to ensure build reproducibility.